### PR TITLE
Removes Vec allocation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,10 +11,8 @@ fn check_if_dir(dir: &str) -> bool {
 }
 
 fn main() {
-    let mut input: Vec<String> = env::args().collect();
-    input.remove(0);
-    input.iter().for_each(|x| {
-        if check_if_dir(x) {
+    env::args().skip(1).for_each(|x| {
+        if check_if_dir(&x) {
             let sep = if x.contains('/') { '/' } else { '\\' };
             let mut dir = x.split(sep).collect::<Vec<&str>>();
             if Path::new(dir[0]).exists() {
@@ -23,11 +21,11 @@ fn main() {
             dir.pop();
             let dir = dir.join(&sep.to_string());
             fs::create_dir_all(&dir).expect("Directory already exists");
-            if !Path::new(x).exists() {
+            if !Path::new(&x).exists() {
                 File::create(String::from(x)).expect("Unable to create file in directory");
             }
         } else {
-            if !Path::new(x).exists() {
+            if !Path::new(&x).exists() {
                 File::create(String::from(x)).expect("Unable to create file");
             }
         }


### PR DESCRIPTION
It looks like you are allocating a Vec and then immediately turning it back into an iterator, you can skip the allocation and just use the `env::args` iterator directly